### PR TITLE
좋아요 , 댓글 수 DTO, mapper, repository 등  수정

### DIFF
--- a/src/main/java/com/example/blogex/domain/comment/dto/CommentFullInfo.java
+++ b/src/main/java/com/example/blogex/domain/comment/dto/CommentFullInfo.java
@@ -1,0 +1,22 @@
+package com.example.blogex.domain.comment.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@Setter
+public class CommentFullInfo {
+    private CommentInfo commentInfo;
+    private Long cntLike;
+
+    @Builder
+    public CommentFullInfo(CommentInfo commentInfo, Long cntLike) {
+        this.commentInfo = commentInfo;
+        this.cntLike = cntLike;
+    }
+}
+

--- a/src/main/java/com/example/blogex/domain/comment/dto/CommentInfo.java
+++ b/src/main/java/com/example/blogex/domain/comment/dto/CommentInfo.java
@@ -6,12 +6,14 @@ import com.example.blogex.domain.user.dto.UserSimpleInfo;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@Setter
 public class CommentInfo {
     private Long id;
     // 댓글목록에서도 게시글 확인할 수 있도록
@@ -19,8 +21,7 @@ public class CommentInfo {
     private UserSimpleInfo userSimpleInfo;
     private String content;
     private LocalDateTime createdAt;
-    private List<ReplyInfo> replies;
-    private int cntLike;
+    private List<ReplyFullInfo> replies;
 
     @Builder
     public CommentInfo(
@@ -29,8 +30,8 @@ public class CommentInfo {
             UserSimpleInfo userSimpleInfo,
             String content,
             LocalDateTime createdAt,
-            List<ReplyInfo> replies,
-            int cntLike
+            List<ReplyFullInfo> replies
+
     ){
         this.id = id;
         this.postInfo = postInfo;
@@ -38,7 +39,6 @@ public class CommentInfo {
         this.content = content;
         this.createdAt = createdAt;
         this.replies = replies;
-        this.cntLike = cntLike;
     }
 
 

--- a/src/main/java/com/example/blogex/domain/comment/dto/CommentStats.java
+++ b/src/main/java/com/example/blogex/domain/comment/dto/CommentStats.java
@@ -1,0 +1,13 @@
+package com.example.blogex.domain.comment.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class CommentStats {
+    private Long id;
+    private Long cntLike;
+}

--- a/src/main/java/com/example/blogex/domain/comment/dto/ReplyFullInfo.java
+++ b/src/main/java/com/example/blogex/domain/comment/dto/ReplyFullInfo.java
@@ -1,0 +1,19 @@
+package com.example.blogex.domain.comment.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@Setter
+public class ReplyFullInfo {
+    private ReplyInfo replyInfo;
+    private Long cntLike;
+
+    public ReplyFullInfo(ReplyInfo replyInfo, Long cntLike) {
+        this.replyInfo = replyInfo;
+        this.cntLike = cntLike;
+    }
+}

--- a/src/main/java/com/example/blogex/domain/comment/dto/ReplyInfo.java
+++ b/src/main/java/com/example/blogex/domain/comment/dto/ReplyInfo.java
@@ -14,18 +14,15 @@ public class ReplyInfo {
     private UserSimpleInfo userSimpleInfo;
     private String content;
     private LocalDateTime createdAt;
-    private int cntLike;
 
     @Builder
     public ReplyInfo(Long id,
                      UserSimpleInfo userSimpleInfo,
                      String content,
-                     LocalDateTime createdAt,
-                     int cntLike) {
+                     LocalDateTime createdAt) {
         this.id = id;
         this.userSimpleInfo = userSimpleInfo;
         this.content = content;
         this.createdAt = createdAt;
-        this.cntLike = cntLike;
     }
 }

--- a/src/main/java/com/example/blogex/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/example/blogex/domain/comment/mapper/CommentMapper.java
@@ -1,10 +1,7 @@
 package com.example.blogex.domain.comment.mapper;
 
 import ch.qos.logback.core.model.ComponentModel;
-import com.example.blogex.domain.comment.dto.CommentCreateRequest;
-import com.example.blogex.domain.comment.dto.CommentCreateResponse;
-import com.example.blogex.domain.comment.dto.CommentInfo;
-import com.example.blogex.domain.comment.dto.ReplyInfo;
+import com.example.blogex.domain.comment.dto.*;
 import com.example.blogex.domain.comment.entitiy.Comment;
 import com.example.blogex.domain.post.mapper.PostMapper;
 import com.example.blogex.domain.user.mapper.UserMapper;
@@ -15,27 +12,54 @@ import org.mapstruct.Mapping;
 
 import java.awt.*;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-@Mapper(componentModel="spring"
-,uses = {UserMapper.class, PostMapper.class})
+@Mapper(componentModel = "spring", uses = UserMapper.class)
 public interface CommentMapper {
 
-    @Mapping(target = "postInfo",source = "post")
-    @Mapping(target="userSimpleInfo",source="user")
+    @Mapping(target = "postInfo", source = "post")
+    @Mapping(target = "userSimpleInfo", source = "user")
     CommentInfo toInfo(Comment comment);
 
     List<CommentInfo> toInfos(List<Comment> comments);
 
-    @Mapping(target="userSimpleInfo",source="user")
+    @Mapping(target = "userSimpleInfo", source = "user")
     ReplyInfo toReplyInfo(Comment comment);
 
     List<ReplyInfo> toReplyInfos(List<Comment> comments);
 
-
-
     CommentCreateResponse toResponse(Comment comment);
 
+    // 댓글 + 좋아요 통계 단일 매핑
+    @Mapping(target = "cntLike", source = "commentStats.cntLike")
+    CommentFullInfo toFullInfo(Comment comment, CommentStats commentStats);
 
+    // 댓글 + 좋아요 통계 리스트 매핑
+    default List<CommentFullInfo> toFullInfos(
+            List<Comment> comments,
+            List<CommentStats> commentStatsList
+    ) {
+        Map<Long, CommentStats> statsMap = commentStatsList.stream()
+                .collect(Collectors.toMap(CommentStats::getId, s -> s));
+        return comments.stream()
+                .map(c -> toFullInfo(c, statsMap.get(c.getId())))
+                .toList();
+    }
 
+    // 답글 + 좋아요 통계 단일 매핑
+    @Mapping(target = "cntLike", source = "commentStats.cntLike")
+    ReplyFullInfo toReplyFullInfo(Comment comment, CommentStats commentStats);
 
+    // 답글 + 좋아요 통계 리스트 매핑
+    default List<ReplyFullInfo> toReplyFullInfos(
+            List<Comment> replies,
+            List<CommentStats> commentStatsList
+    ) {
+        Map<Long, CommentStats> statsMap = commentStatsList.stream()
+                .collect(Collectors.toMap(CommentStats::getId, s -> s));
+        return replies.stream()
+                .map(c -> toReplyFullInfo(c, statsMap.get(c.getId())))
+                .toList();
+    }
 }

--- a/src/main/java/com/example/blogex/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/blogex/domain/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.example.blogex.domain.comment.repository;
 
+import com.example.blogex.domain.comment.dto.CommentStats;
 import com.example.blogex.domain.comment.entitiy.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -52,4 +53,17 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     order by size(c.replies) desc
     """)
     List<Comment> findByPostIdOrderByChildrenCount(@Param("postId") Long postId);
+
+
+    @Query("""
+    select new com.example.blogex.domain.comment.dto.CommentStats(
+    c.id,
+    count (l)
+    )
+    from Comment c
+    left join c.likes l
+    where c.id in :ids
+    group by c.id
+    """)
+    List<CommentStats> getCommentStats(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/example/blogex/domain/post/dto/PostFullInfo.java
+++ b/src/main/java/com/example/blogex/domain/post/dto/PostFullInfo.java
@@ -1,0 +1,17 @@
+package com.example.blogex.domain.post.dto;
+
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostFullInfo {
+
+    private PostInfo postInfo;
+    private Long cntLike;
+    private Long cntComment;
+
+
+}

--- a/src/main/java/com/example/blogex/domain/post/dto/PostInfo.java
+++ b/src/main/java/com/example/blogex/domain/post/dto/PostInfo.java
@@ -17,8 +17,6 @@ public class PostInfo {
     private Long id;
     private UserSimpleInfo userSimpleInfo;
     private String title;
-    private int commentCount;
-    private int likeCount;
     private String previewImageUrl;
     private String previewImageOcr;
     private LocalDateTime createdAt;
@@ -30,8 +28,6 @@ public class PostInfo {
             Long id,
             UserSimpleInfo userSimpleInfo,
             String title,
-            int commentCount,
-            int likeCount,
             String previewImageOcr,
             String previewImageUrl,
             LocalDateTime createdAt,
@@ -41,8 +37,6 @@ public class PostInfo {
         this.id = id;
         this.userSimpleInfo = userSimpleInfo;
         this.title = title;
-        this.commentCount = commentCount;
-        this.likeCount = likeCount;
         this.previewImageOcr = previewImageOcr;
         this.previewImageUrl = previewImageUrl;
         this.createdAt = createdAt;

--- a/src/main/java/com/example/blogex/domain/post/dto/PostStats.java
+++ b/src/main/java/com/example/blogex/domain/post/dto/PostStats.java
@@ -1,0 +1,21 @@
+package com.example.blogex.domain.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostStats {
+    private Long id;
+    private Long cntLike;
+    private Long cntComment;
+
+    @Builder
+    public PostStats(Long id, Long cntLike, Long cntComment) {
+        this.id = id;
+        this.cntLike = cntLike;
+        this.cntComment = cntComment;
+    }
+
+}

--- a/src/main/java/com/example/blogex/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/example/blogex/domain/post/mapper/PostMapper.java
@@ -1,27 +1,39 @@
 package com.example.blogex.domain.post.mapper;
 
 
-import com.example.blogex.domain.post.dto.PostCreateRequest;
-import com.example.blogex.domain.post.dto.PostCreateResponse;
-import com.example.blogex.domain.post.dto.PostInfo;
-import com.example.blogex.domain.post.dto.PostUpdateRequest;
+import com.example.blogex.domain.post.dto.*;
 import com.example.blogex.domain.post.entitiy.Post;
 import com.example.blogex.domain.user.mapper.UserMapper;
 import org.mapstruct.*;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-@Mapper(componentModel = "spring",
-uses = UserMapper.class)
+@Mapper(componentModel = "spring", uses = UserMapper.class)
 public interface PostMapper {
 
-    @Mapping(target = "previewImageUrl",source="previewImage")
-    @Mapping(target="userSimpleInfo",source="user")
+    @Mapping(target = "previewImageUrl", source = "previewImage")
+    @Mapping(target = "userSimpleInfo", source = "user")
     PostInfo toInfo(Post post);
 
     List<PostInfo> toInfos(List<Post> posts);
 
-    @Mapping(target = "userInfo", source="user")
+    @Mapping(target = "userInfo", source = "user")
     PostCreateResponse toResponse(Post post);
 
+    @Mapping(target = "cntLike",    source = "postStats.cntLike")
+    @Mapping(target = "cntComment", source = "postStats.cntComment")
+    PostFullInfo toFullInfo(PostInfo postInfo, PostStats postStats);
+
+    default List<PostFullInfo> toFullInfos(
+            List<PostInfo> postInfos,
+            List<PostStats> postStatsList
+    ) {
+        Map<Long, PostStats> statsMap = postStatsList.stream()
+                .collect(Collectors.toMap(PostStats::getId, s -> s));
+        return postInfos.stream()
+                .map(info -> toFullInfo(info, statsMap.get(info.getId())))
+                .toList();
+    }
 }

--- a/src/main/java/com/example/blogex/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/blogex/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.example.blogex.domain.post.repository;
 
+import com.example.blogex.domain.post.dto.PostStats;
 import com.example.blogex.domain.post.entitiy.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -157,4 +158,20 @@ public interface PostRepository extends JpaRepository<Post,Long> {
     order by p.createdAt desc
 """)
     List<Post> findByUserIdAndTag(@Param("UserId") Long UserId, @Param("kw") String kw);
+
+
+
+    @Query("""
+    select new com.example.blogex.domain.post.dto.PostStats(
+    p.id,
+    count (c),
+    count (l)
+    )
+    from Post p
+    left join p.comments c
+    left join p.likes l
+    where p.id IN :ids
+    group by p.id
+""")
+    List<PostStats> findPostStatsByIds(@Param("ids") List<Long> ids);
 }


### PR DESCRIPTION
post,comment의 좋아요, post의 댓글 수 등의 정보를 메타데이터와 분리하면서,
또다른 dto에 하나로 묶어서 리스트로 반환시키기 위한 수정